### PR TITLE
feat: support feature-file variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The project is deliberately pragmatic:
 - fail-fast validation with dedicated `ConfigError` and `IntegrationError`
   exceptions
 - explicit `$ref` and `$var` markers for dependencies and reusable values
+- opt-in `{{var:name}}` substitution for feature files
 - lifecycle activation helpers for `environment.py`
 - config-driven parser helpers for Behave custom types
 - tag-driven scenario cycling with `@cycling(N)`
@@ -119,6 +120,10 @@ Markers are explicit on purpose:
 - `$ref` + `attr`: inject one attribute path from another object
 - `$var`: inject a named value from the root `variables` section
 
+If you want to reuse those same root variables directly in `.feature` files,
+call `substitute_feature_variables(context)` from `before_all()` after
+`install()`. Feature placeholders use the explicit `{{var:name}}` syntax.
+
 `install()` validates the whole configuration up front. Invalid scopes, bad
 imports, unknown `$ref` / `$var` entries, and object-reference cycles fail fast
 with messages that include the config path and the relevant object field.
@@ -146,6 +151,23 @@ features/
 If your suite uses custom Behave types, `configure_parsers(CONFIG_PATH)` can
 move matcher selection and type registration into the same YAML config. This is
 import-time setup, so keep it at module level in `environment.py`.
+
+### Feature-file variables
+
+If you want to reuse root config values directly in Gherkin, call
+`substitute_feature_variables(context)` after `install(context, CONFIG_PATH)`:
+
+```python
+from behave_toolkit import substitute_feature_variables
+
+
+def before_all(context):
+    install(context, CONFIG_PATH)
+    substitute_feature_variables(context)
+```
+
+This replaces `{{var:name}}` placeholders in feature names, descriptions, step
+text, docstrings, and tables. Tags are intentionally left unchanged.
 
 ### Scenario cycling
 
@@ -184,6 +206,16 @@ python -m sphinx -b html docs/behave-toolkit docs/_build/behave-toolkit
 The generated pages include grouped step catalogs, one page per step
 definition, one page per custom parse type, and links from typed parameters
 back to their type pages.
+
+If your feature files use `{{var:name}}`, pass the same toolkit config to the
+docs generator so example matching sees the substituted text:
+
+```bash
+behave-toolkit-docs \
+  --features-dir features \
+  --output-dir docs/behave-toolkit \
+  --config-path features/behave-toolkit.yaml
+```
 
 ## Project documentation
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -34,6 +34,7 @@ from behave_toolkit import (
     load_config,
     load_yaml_file,
     load_yaml_text,
+    substitute_feature_variables,
 )
 ```
 
@@ -50,6 +51,7 @@ from behave_toolkit import (
 | API | Purpose | Typical Behave hook |
 | --- | --- | --- |
 | `install(context, config_path, namespace="toolkit", activate_global=True)` | Load and validate config, attach the manager, and activate global objects. | `before_all` |
+| `substitute_feature_variables(context, namespace="toolkit")` | Replace `{{var:name}}` placeholders in parsed feature models using root config variables. | `before_all` |
 | `expand_scenario_cycles(context)` | Expand tagged plain scenarios that use `@cycling(N)` before feature execution starts. | `before_all` |
 | `configure_parsers(config_path)` | Configure Behave step matcher defaults and register custom types from YAML. | module import time |
 | `configure_test_logging(log_path, logger_name="behave-tests", level="INFO", console=True, console_stream=None, mode="w")` | Configure one dedicated logger for a persistent test-run file plus optional console output. Recommended when one log file is enough. | usually `before_all` |
@@ -70,7 +72,7 @@ enough.
 
 | API | Purpose |
 | --- | --- |
-| `generate_step_docs(features_dir, output_dir, *, site_title="Behave step documentation", max_examples_per_step=3)` | Generate Sphinx-ready step/type reference pages from Python. |
+| `generate_step_docs(features_dir, output_dir, *, site_title="Behave step documentation", max_examples_per_step=3, config_path=None)` | Generate Sphinx-ready step/type reference pages from Python. Pass `config_path` when examples use `{{var:name}}`. |
 | `DocumentationResult` | Return type exposing `output_dir`, `step_count`, and `type_count`. |
 
 ## Cycle inspection helpers

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@
 | Key | Type | Purpose |
 | --- | --- | --- |
 | `version` | `int` | Config format version. Defaults to `1`. |
-| `variables` | mapping | Reusable literal values referenced with `$var`. |
+| `variables` | mapping | Reusable literal values referenced with `$var` in YAML or `{{var:name}}` in feature files. |
 | `objects` | mapping | Named object definitions managed by the toolkit. |
 | `parsers` | mapping | Optional Behave parser/type helpers configured at import time. |
 | `logging` | mapping | Optional named logger definitions configured from `before_all()`. |
@@ -67,6 +67,28 @@ The config stays explicit by using dedicated markers instead of hidden magic.
 | `$ref` + `attr` | Reuse one attribute path from another object. |
 | `$var` | Reuse a root-level variable from the config. |
 
+## Feature-file placeholders
+
+If you want to reuse root variables directly in Gherkin, call
+`substitute_feature_variables(context)` from `before_all()` after `install()`.
+
+Feature placeholders use this syntax:
+
+```gherkin
+Scenario: Login against {{var:environment_name}}
+  Given I open {{var:base_url}}
+```
+
+The helper currently rewrites:
+
+- feature, rule, background, and scenario names
+- description lines
+- step text
+- docstrings
+- table headings and cells, including `Scenario Outline` example tables
+
+Tags are intentionally not rewritten in this first version.
+
 ## Example with references
 
 ```yaml
@@ -119,6 +141,10 @@ Behave context. This catches problems early, including:
 - unknown `$var` names
 - cycles between object references
 - invalid wider-to-narrower scope dependencies
+
+`substitute_feature_variables()` then validates runtime feature placeholders when
+you opt into that helper. Unknown names, circular variable references, and
+non-scalar resolved values fail fast with `IntegrationError`.
 
 ```{tip}
 If you want to inject an instance under a shorter or more domain-specific name,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -105,6 +105,22 @@ def before_all(context):
     install(context, CONFIG_PATH)
 ```
 
+If you want to reuse root config variables directly in `.feature` files, call
+`substitute_feature_variables(context)` from `before_all()` after `install()`:
+
+```python
+from behave_toolkit import substitute_feature_variables
+
+
+def before_all(context):
+    install(context, CONFIG_PATH)
+    substitute_feature_variables(context)
+```
+
+Feature placeholders use `{{var:name}}`. They apply to feature/scenario names,
+description lines, step text, docstrings, and tables. Tags are intentionally
+left unchanged.
+
 ## What happens at runtime
 
 1. `install()` loads and validates the YAML file or config directory, attaches
@@ -118,7 +134,9 @@ def before_all(context):
 4. Instances are injected onto the Behave context using either `inject_as` or
    the object name itself.
 5. `configure_parsers()` is optional import-time setup for custom types.
-6. `expand_scenario_cycles()` is an optional `before_all()` helper for
+6. `substitute_feature_variables()` is an optional `before_all()` helper for
+   `{{var:name}}` placeholders in parsed feature files.
+7. `expand_scenario_cycles()` is an optional `before_all()` helper for
    `@cycling(N)`.
 
 ## Optional: keep one persistent test log

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,9 @@ Start with the small core:
 - call `install()` from `before_all()`
 - activate `feature` and `scenario` scopes from the matching Behave hooks
 
-Then add optional layers only when you need them: parser helpers, scenario
-cycling, generated step docs, or YAML-defined named loggers.
+Then add optional layers only when you need them: feature-file variables,
+parser helpers, scenario cycling, generated step docs, or YAML-defined named
+loggers.
 
 ```{toctree}
 :hidden:
@@ -115,6 +116,7 @@ execution model behind a heavy framework.
 - config-driven parser helpers with matcher selection and enum shortcuts
 - tag-driven scenario cycling with `@cycling(N)`
 - explicit object references with `$ref` and reusable values with `$var`
+- opt-in `{{var:name}}` substitution inside parsed feature files
 - a small persistent test logger with `configure_test_logging()`, plus optional
   YAML-configured named loggers for larger suites
 - fail-fast `ConfigError` and `IntegrationError` messages

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -18,6 +18,7 @@ The current release only supports these three runtime scopes.
 | --- | --- | --- |
 | `expand_scenario_cycles(context)` | `before_all` | Expand tagged plain scenarios that use `@cycling(N)` before any feature runs. |
 | `install(context, config_path, ...)` | `before_all` | Load the config, validate it, attach the manager, and optionally activate global objects. |
+| `substitute_feature_variables(context)` | `before_all` | Replace `{{var:name}}` placeholders in parsed feature models using root config variables. |
 | `configure_test_logging(log_path, ...)` | usually `before_all` | Configure one dedicated test-run logger writing to a chosen file, with optional console output. |
 | `configure_loggers(context, ...)` | usually `before_all` | Materialize loggers from the optional YAML `logging:` section. |
 | `activate_global_scope(context, ...)` | `before_all` | Explicitly activate global objects when you disable `activate_global`. |
@@ -28,6 +29,13 @@ The current release only supports these three runtime scopes.
 `activate_scope(context, Scope.FEATURE)` and friends all route through the same
 generic activation logic. The dedicated helpers are just the friendlier,
 hook-specific wrappers.
+
+If you use both feature-variable substitution and scenario cycling, the clearest
+ordering is:
+
+1. `install(context, CONFIG_PATH)`
+2. `substitute_feature_variables(context)`
+3. `expand_scenario_cycles(context)`
 
 ## Global scope behavior
 

--- a/docs/step-documentation.md
+++ b/docs/step-documentation.md
@@ -23,6 +23,13 @@ After a plain `pip install behave-toolkit`, you can:
 behave-toolkit-docs --features-dir features --output-dir docs/behave-toolkit
 ```
 
+If your feature files use `{{var:name}}`, pass the same toolkit config so step
+examples are resolved before matching:
+
+```bash
+behave-toolkit-docs --features-dir features --output-dir docs/behave-toolkit --config-path features/behave-toolkit.yaml
+```
+
 If you prefer to drive the generator from Python, the public API is:
 
 ```python
@@ -32,6 +39,7 @@ result = generate_step_docs(
     "features",
     "docs/behave-toolkit",
     site_title="QA Step Catalog",
+    config_path="features/behave-toolkit.yaml",
 )
 print(result.step_count, result.type_count)
 ```
@@ -63,6 +71,9 @@ pip install behave-toolkit
 behave-toolkit-docs --features-dir features --output-dir docs/behave-toolkit
 python -m sphinx -b html docs/behave-toolkit docs/_build/behave-toolkit
 ```
+
+Keep `--config-path` only if your feature files actually use
+`{{var:name}}` placeholders. Otherwise the default command stays enough.
 
 ## Recommended type-registration pattern
 

--- a/src/behave_toolkit/__init__.py
+++ b/src/behave_toolkit/__init__.py
@@ -13,6 +13,7 @@ from .config import (
 )
 from .cycles import expand_scenario_cycles, format_cycle_progress, get_cycle_progress
 from .errors import ConfigError, DocumentationError, IntegrationError, ToolkitError
+from .feature_variables import substitute_feature_variables
 from .logging_support import configure_test_logging
 from .parsers import configure_parsers
 from .plugin import (
@@ -56,6 +57,7 @@ __all__ = [
     "load_config",
     "load_yaml_file",
     "load_yaml_text",
+    "substitute_feature_variables",
 ]
 
 __version__ = "0.1.0"

--- a/src/behave_toolkit/feature_variables.py
+++ b/src/behave_toolkit/feature_variables.py
@@ -1,0 +1,344 @@
+"""Helpers for opt-in variable substitution inside parsed Behave feature models."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+import re
+from typing import Any
+
+from .errors import IntegrationError
+
+FEATURE_VARIABLE_PATTERN = re.compile(r"\{\{\s*var\s*:\s*([^{}]+?)\s*\}\}")
+RUNNER_VARIABLES_ATTRIBUTE = "_behave_toolkit_feature_variables_substituted"
+
+
+@dataclass(slots=True)
+class _VariableResolutionState:
+    variable_stack: list[str] = field(default_factory=list)
+
+
+class _FeatureVariableSubstituter:
+    def __init__(self, variables: Mapping[str, Any]) -> None:
+        self._variables = variables
+        self._seen_nodes: set[int] = set()
+
+    def apply(self, features: Iterable[Any]) -> int:
+        total = 0
+        for feature in features:
+            total += self._substitute_node(feature)
+        return total
+
+    def _substitute_node(self, node: Any) -> int:
+        if node is None:
+            return 0
+
+        node_id = id(node)
+        if node_id in self._seen_nodes:
+            return 0
+        self._seen_nodes.add(node_id)
+
+        total = 0
+        total += self._substitute_name(node)
+        total += self._substitute_description(node)
+
+        background = getattr(node, "background", None)
+        if background is not None:
+            total += self._substitute_node(background)
+
+        table = getattr(node, "table", None)
+        if table is not None:
+            total += self._substitute_table(table, owner=node)
+
+        for step in list(getattr(node, "steps", []) or []):
+            total += self._substitute_step(step)
+
+        for child in list(getattr(node, "run_items", []) or []):
+            total += self._substitute_node(child)
+
+        for child in list(getattr(node, "scenarios", []) or []):
+            total += self._substitute_node(child)
+
+        for child in list(getattr(node, "examples", []) or []):
+            total += self._substitute_node(child)
+
+        return total
+
+    def _substitute_name(self, node: Any) -> int:
+        name = getattr(node, "name", None)
+        if not isinstance(name, str):
+            return 0
+
+        updated, replacements = self._replace_text(
+            name,
+            location=self._location(node, "name"),
+        )
+        if replacements:
+            node.name = updated
+        return replacements
+
+    def _substitute_description(self, node: Any) -> int:
+        description = getattr(node, "description", None)
+        if not isinstance(description, list):
+            return 0
+
+        total = 0
+        changed = False
+        for index, line in enumerate(description, start=1):
+            if not isinstance(line, str):
+                continue
+
+            updated, replacements = self._replace_text(
+                line,
+                location=self._location(node, f"description line {index}"),
+            )
+            if replacements:
+                description[index - 1] = updated
+                changed = True
+                total += replacements
+
+        if changed:
+            node.description = description
+        return total
+
+    def _substitute_step(self, step: Any) -> int:
+        step_id = id(step)
+        if step_id in self._seen_nodes:
+            return 0
+        self._seen_nodes.add(step_id)
+
+        total = 0
+        if isinstance(getattr(step, "name", None), str):
+            updated, replacements = self._replace_text(
+                step.name,
+                location=self._location(step, "step text"),
+            )
+            if replacements:
+                step.name = updated
+                total += replacements
+
+        if isinstance(getattr(step, "text", None), str):
+            updated, replacements = self._replace_text(
+                step.text,
+                location=self._location(step, "docstring"),
+            )
+            if replacements:
+                step.text = updated
+                total += replacements
+
+        table = getattr(step, "table", None)
+        if table is not None:
+            total += self._substitute_table(table, owner=step)
+
+        return total
+
+    def _substitute_table(self, table: Any, *, owner: Any) -> int:
+        table_id = id(table)
+        if table_id in self._seen_nodes:
+            return 0
+        self._seen_nodes.add(table_id)
+
+        total = 0
+        headings = getattr(table, "headings", None)
+        if isinstance(headings, list):
+            for column_index, heading in enumerate(headings, start=1):
+                if not isinstance(heading, str):
+                    continue
+
+                updated, replacements = self._replace_text(
+                    heading,
+                    location=self._location(owner, f"table heading {column_index}"),
+                )
+                if replacements:
+                    headings[column_index - 1] = updated
+                    total += replacements
+
+        rows = getattr(table, "rows", None)
+        if rows is None:
+            return total
+
+        for row_index, row in enumerate(rows, start=1):
+            cells = getattr(row, "cells", None)
+            if not isinstance(cells, list):
+                continue
+
+            for column_index, cell in enumerate(cells, start=1):
+                if not isinstance(cell, str):
+                    continue
+
+                updated, replacements = self._replace_text(
+                    cell,
+                    location=self._location(
+                        owner,
+                        f"table row {row_index} cell {column_index}",
+                    ),
+                )
+                if replacements:
+                    cells[column_index - 1] = updated
+                    total += replacements
+
+        return total
+
+    def _replace_text(self, text: str, *, location: str) -> tuple[str, int]:
+        replacements = 0
+
+        def replace(match: re.Match[str]) -> str:
+            nonlocal replacements
+            variable_name = match.group(1).strip()
+            if not variable_name:
+                raise IntegrationError(
+                    "Could not substitute behave-toolkit feature variable at "
+                    f"{location}: empty variable name. Use '{{{{var:name}}}}'."
+                )
+
+            replacements += 1
+            return self._resolve_variable(
+                variable_name,
+                location=location,
+                state=_VariableResolutionState(),
+            )
+
+        return FEATURE_VARIABLE_PATTERN.sub(replace, text), replacements
+
+    def _resolve_variable(
+        self,
+        variable_name: str,
+        *,
+        location: str,
+        state: _VariableResolutionState,
+    ) -> str:
+        if variable_name in state.variable_stack:
+            cycle = " -> ".join([*state.variable_stack, variable_name])
+            raise IntegrationError(
+                "Could not substitute behave-toolkit feature variable at "
+                f"{location}: circular variable reference detected: {cycle}."
+            )
+
+        try:
+            raw_value = self._variables[variable_name]
+        except KeyError as exc:
+            known = ", ".join(sorted(self._variables)) or "<none>"
+            raise IntegrationError(
+                "Could not substitute behave-toolkit feature variable at "
+                f"{location}: unknown variable '{variable_name}'. Known variables: "
+                f"{known}."
+            ) from exc
+
+        state.variable_stack.append(variable_name)
+        try:
+            value = self._resolve_variable_value(
+                raw_value,
+                location=location,
+                state=state,
+            )
+        finally:
+            state.variable_stack.pop()
+
+        return self._render_scalar_value(variable_name, value, location=location)
+
+    def _resolve_variable_value(
+        self,
+        value: Any,
+        *,
+        location: str,
+        state: _VariableResolutionState,
+    ) -> Any:
+        if not isinstance(value, Mapping):
+            return value
+
+        if "$var" not in value:
+            return value
+
+        extra_keys = set(value) - {"$var"}
+        if extra_keys:
+            extras = ", ".join(sorted(extra_keys))
+            raise IntegrationError(
+                "Could not substitute behave-toolkit feature variable at "
+                f"{location}: unsupported keys for nested $var marker: {extras}."
+            )
+
+        nested_name = value.get("$var")
+        if not isinstance(nested_name, str) or not nested_name.strip():
+            raise IntegrationError(
+                "Could not substitute behave-toolkit feature variable at "
+                f"{location}: nested $var marker requires a non-empty string."
+            )
+
+        return self._resolve_variable(
+            nested_name.strip(),
+            location=location,
+            state=state,
+        )
+
+    def _render_scalar_value(self, variable_name: str, value: Any, *, location: str) -> str:
+        if isinstance(value, bool):
+            return "true" if value else "false"
+
+        if isinstance(value, (str, int, float)):
+            return str(value)
+
+        raise IntegrationError(
+            "Could not substitute behave-toolkit feature variable at "
+            f"{location}: variable '{variable_name}' resolved to unsupported value "
+            f"type '{type(value).__name__}'. Use a scalar string, number, or "
+            "boolean."
+        )
+
+    def _location(self, node: Any, label: str) -> str:
+        filename = getattr(node, "filename", None)
+        line = getattr(node, "line", None)
+        owner = type(node).__name__
+        label = f"{owner} {label}"
+
+        if isinstance(filename, str) and filename:
+            if isinstance(line, int):
+                return f"{filename}:{line} ({label})"
+            return f"{filename} ({label})"
+
+        if isinstance(line, int):
+            return f"line {line} ({label})"
+
+        return label
+
+
+def substitute_feature_model_variables(
+    features: Iterable[Any],
+    variables: Mapping[str, Any],
+) -> int:
+    """Replace `{{var:name}}` placeholders inside parsed Behave feature models."""
+
+    return _FeatureVariableSubstituter(variables).apply(features)
+
+
+def substitute_feature_variables(
+    context: object,
+    *,
+    namespace: str = "toolkit",
+) -> int:
+    """Replace `{{var:name}}` placeholders in already-parsed feature models."""
+
+    manager = getattr(context, namespace, None)
+    config = getattr(manager, "config", None)
+    variables = getattr(config, "variables", None)
+    if not isinstance(variables, Mapping):
+        raise IntegrationError(
+            f"Context does not contain a behave-toolkit manager at '{namespace}'. "
+            "Call install(context, ...) from before_all before calling "
+            "substitute_feature_variables(context)."
+        )
+
+    runner = getattr(context, "_runner", None)
+    features = getattr(runner, "features", None)
+    if runner is None or features is None:
+        raise IntegrationError(
+            "behave-toolkit feature-variable substitution requires the real Behave "
+            "context with _runner.features. Call substitute_feature_variables(context) "
+            "from before_all()."
+        )
+
+    if getattr(runner, RUNNER_VARIABLES_ATTRIBUTE, False):
+        return 0
+
+    replacements = substitute_feature_model_variables(features, variables)
+    setattr(runner, RUNNER_VARIABLES_ATTRIBUTE, True)
+    return replacements

--- a/src/behave_toolkit/step_docs.py
+++ b/src/behave_toolkit/step_docs.py
@@ -30,7 +30,9 @@ from behave.parser import parse_file
 from behave.runner_util import PathManager, exec_file
 from behave.step_registry import registry, setup_step_decorators
 
-from .errors import DocumentationError
+from .config import load_yaml_file
+from .errors import ConfigError, DocumentationError, IntegrationError
+from .feature_variables import substitute_feature_model_variables
 from .internal import callable_source_info, snapshot_type_registries
 
 FIELD_PATTERN = re.compile(r"\{([^}]*)\}")
@@ -177,11 +179,17 @@ def generate_step_docs(
     *,
     site_title: str = "Behave step documentation",
     max_examples_per_step: int = 3,
+    config_path: str | Path | None = None,
 ) -> DocumentationResult:
     """Generate Sphinx-ready documentation sources for a Behave project."""
 
     resolved_features_dir = Path(features_dir).expanduser().resolve()
     resolved_output_dir = Path(output_dir).expanduser().resolve()
+    resolved_config_path = (
+        Path(config_path).expanduser().resolve()
+        if config_path is not None
+        else None
+    )
 
     if max_examples_per_step < 1:
         raise DocumentationError("'max_examples_per_step' must be at least 1.")
@@ -189,6 +197,7 @@ def generate_step_docs(
     catalog = _collect_catalog(
         resolved_features_dir,
         max_examples_per_step=max_examples_per_step,
+        config_path=resolved_config_path,
     )
     _render_catalog(catalog, resolved_output_dir, site_title)
 
@@ -248,7 +257,12 @@ def _preserve_behave_state() -> Iterator[None]:
         factory._current_matcher = saved_current_matcher  # pylint: disable=protected-access
 
 
-def _collect_catalog(features_dir: Path, *, max_examples_per_step: int) -> _Catalog:
+def _collect_catalog(
+    features_dir: Path,
+    *,
+    max_examples_per_step: int,
+    config_path: Path | None,
+) -> _Catalog:
     if not features_dir.is_dir():
         raise DocumentationError(
             f"Behave features directory '{features_dir}' does not exist."
@@ -263,13 +277,20 @@ def _collect_catalog(features_dir: Path, *, max_examples_per_step: int) -> _Cata
     project_root = features_dir.parent
     with _preserve_behave_state():
         _load_behave_project(project_root, features_dir, steps_dir)
+        feature_variables = _load_feature_example_variables(config_path)
         type_docs = _build_type_docs(project_root)
         step_docs = _build_step_docs(project_root, type_docs)
         if not step_docs:
             raise DocumentationError(
                 f"No step definitions were loaded from '{steps_dir}'."
             )
-        _attach_examples(step_docs, features_dir, project_root, max_examples_per_step)
+        _attach_examples(
+            step_docs,
+            features_dir,
+            project_root,
+            max_examples_per_step,
+            feature_variables=feature_variables,
+        )
         _link_types_to_steps(step_docs, type_docs)
 
     return _Catalog(
@@ -298,6 +319,19 @@ def _load_behave_project(project_root: Path, features_dir: Path, steps_dir: Path
         for step_directory in step_directories:
             for step_file in sorted(step_directory.glob("*.py")):
                 _load_step_file(step_file)
+
+
+def _load_feature_example_variables(config_path: Path | None) -> dict[str, Any] | None:
+    if config_path is None:
+        return None
+
+    try:
+        return load_yaml_file(config_path).variables
+    except ConfigError as exc:
+        raise DocumentationError(
+            "Could not load behave-toolkit config "
+            f"'{config_path}' for feature example substitution: {exc}"
+        ) from exc
 
 
 def _discover_step_directories(steps_dir: Path) -> list[Path]:
@@ -647,6 +681,8 @@ def _attach_examples(
     features_dir: Path,
     project_root: Path,
     max_examples_per_step: int,
+    *,
+    feature_variables: dict[str, Any] | None = None,
 ) -> None:
     docs_by_matcher = {
         (
@@ -665,6 +701,15 @@ def _attach_examples(
             raise DocumentationError(
                 f"Could not parse feature file '{feature_file}': {exc}"
             ) from exc
+
+        if feature_variables is not None:
+            try:
+                substitute_feature_model_variables([feature], feature_variables)
+            except IntegrationError as exc:
+                raise DocumentationError(
+                    "Could not substitute behave-toolkit feature variables in "
+                    f"'{feature_file}': {exc}"
+                ) from exc
 
         for scenario in feature.walk_scenarios():
             for step in scenario.all_steps:
@@ -1799,6 +1844,13 @@ def main(argv: list[str] | None = None) -> int:
         default=3,
         help="Maximum number of example step usages to record per step definition.",
     )
+    parser.add_argument(
+        "--config-path",
+        help=(
+            "Optional behave-toolkit config file or directory used to resolve "
+            "{{var:name}} placeholders in feature files."
+        ),
+    )
 
     args = parser.parse_args(argv)
     try:
@@ -1807,6 +1859,7 @@ def main(argv: list[str] | None = None) -> int:
             args.output_dir,
             site_title=args.site_title,
             max_examples_per_step=args.max_examples,
+            config_path=args.config_path,
         )
     except DocumentationError as exc:
         print(str(exc), file=sys.stderr)

--- a/tests/test_feature_variables.py
+++ b/tests/test_feature_variables.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from behave.configuration import Configuration
+from behave.model import Feature
+from behave.parser import parse_file
+from behave.runner import Context, Runner
+
+from behave_toolkit import IntegrationError, install, substitute_feature_variables
+
+
+class FeatureVariableSubstitutionTests(unittest.TestCase):
+    def test_substitute_feature_variables_replaces_feature_text_nodes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            feature = self._parse_feature(
+                root,
+                """
+                Feature: {{var:suite_name}}
+                  About {{var:run_label}}
+
+                  Background: Shared {{var:run_label}} setup
+                    Given a background step {{var:user_kind}}
+
+                  Scenario: Login {{var:run_label}}
+                    Given I use {{var:user_kind}}
+                      \"\"\"
+                      doc {{var:doc_value}}
+                      \"\"\"
+                    And a table
+                      | {{var:column_name}} | state |
+                      | {{var:cell_value}} | ok |
+                """,
+            )
+            context = self._install_context(
+                feature,
+                """
+                version: 1
+                variables:
+                  suite_name: Billing smoke
+                  run_label: nightly
+                  user_kind: active
+                  doc_value: ready
+                  column_name: target
+                  cell_value: report.json
+                """,
+            )
+
+            replacements = substitute_feature_variables(context)
+            second_pass = substitute_feature_variables(context)
+
+            scenario = feature.walk_scenarios()[0]
+            self.assertEqual(replacements, 9)
+            self.assertEqual(second_pass, 0)
+            self.assertEqual(feature.name, "Billing smoke")
+            self.assertEqual(feature.description, ["About nightly"])
+            self.assertIsNotNone(feature.background)
+            self.assertEqual(feature.background.name, "Shared nightly setup")
+            self.assertEqual(feature.background.steps[0].name, "a background step active")
+            self.assertEqual(scenario.name, "Login nightly")
+            self.assertEqual(scenario.steps[0].name, "I use active")
+            self.assertEqual(scenario.steps[0].text, "doc ready")
+            self.assertEqual(scenario.steps[1].table.headings, ["target", "state"])
+            self.assertEqual(scenario.steps[1].table.rows[0].cells, ["report.json", "ok"])
+
+    def test_substitute_feature_variables_supports_nested_variable_references(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            feature = self._parse_feature(
+                root,
+                """
+                Feature: Nested vars
+
+                  Scenario: Alias
+                    Given the status is {{var:selected_status}}
+                """,
+            )
+            context = self._install_context(
+                feature,
+                """
+                version: 1
+                variables:
+                  base_status: active
+                  selected_status:
+                    $var: base_status
+                """,
+            )
+
+            replacements = substitute_feature_variables(context)
+
+            self.assertEqual(replacements, 1)
+            self.assertEqual(feature.walk_scenarios()[0].steps[0].name, "the status is active")
+
+    def test_substitute_feature_variables_updates_scenario_outline_examples(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            feature = self._parse_feature(
+                root,
+                """
+                Feature: Outline feature
+
+                  Scenario Outline: {{var:suite_name}} <kind>
+                    Given {{var:prefix}} <kind>
+
+                    Examples:
+                      | kind |
+                      | {{var:first_kind}} |
+                      | guest |
+                """,
+            )
+            context = self._install_context(
+                feature,
+                """
+                version: 1
+                variables:
+                  suite_name: Login
+                  prefix: hello
+                  first_kind: active
+                """,
+            )
+
+            substitute_feature_variables(context)
+
+            outline = feature.run_items[0]
+            self.assertEqual(outline.name, "Login <kind>")
+            self.assertEqual(outline.steps[0].name, "hello <kind>")
+            self.assertEqual(outline.examples[0].table.rows[0].cells[0], "active")
+            self.assertEqual(
+                [scenario.name for scenario in outline.scenarios],
+                ["Login active -- @1.1 ", "Login guest -- @1.2 "],
+            )
+            self.assertEqual(
+                [scenario.steps[0].name for scenario in outline.scenarios],
+                ["hello active", "hello guest"],
+            )
+
+    def test_substitute_feature_variables_requires_install(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            feature = self._parse_feature(
+                Path(tmpdir),
+                """
+                Feature: Missing install
+
+                  Scenario: Broken
+                    Given a step
+                """,
+            )
+            context = self._make_context([feature])
+
+            with self.assertRaises(IntegrationError) as exc:
+                substitute_feature_variables(context)
+
+        self.assertIn("install(context, ...)", str(exc.exception))
+        self.assertIn("before_all", str(exc.exception))
+
+    def test_substitute_feature_variables_rejects_unknown_variables(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            feature = self._parse_feature(
+                root,
+                """
+                Feature: Unknown variable
+
+                  Scenario: Broken
+                    Given a step {{var:missing_name}}
+                """,
+            )
+            context = self._install_context(
+                feature,
+                """
+                version: 1
+                variables:
+                  known_name: ok
+                """,
+            )
+
+            with self.assertRaises(IntegrationError) as exc:
+                substitute_feature_variables(context)
+
+        message = str(exc.exception)
+        self.assertIn(str(feature.filename), message)
+        self.assertIn("missing_name", message)
+        self.assertIn("known_name", message)
+
+    def test_substitute_feature_variables_rejects_non_scalar_values(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            feature = self._parse_feature(
+                root,
+                """
+                Feature: Non scalar variable
+
+                  Scenario: Broken
+                    Given a step {{var:matrix}}
+                """,
+            )
+            context = self._install_context(
+                feature,
+                """
+                version: 1
+                variables:
+                  matrix:
+                    row:
+                      - 1
+                      - 2
+                """,
+            )
+
+            with self.assertRaises(IntegrationError) as exc:
+                substitute_feature_variables(context)
+
+        self.assertIn("matrix", str(exc.exception))
+        self.assertIn("scalar string, number, or boolean", str(exc.exception))
+
+    def _install_context(self, feature: Feature, config_text: str) -> Context:
+        context = self._make_context([feature])
+        config_path = Path(feature.filename).with_name("behave-toolkit.yaml")
+        config_path.write_text(textwrap.dedent(config_text).strip(), encoding="utf-8")
+        install(context, config_path)
+        return context
+
+    def _parse_feature(self, directory: Path, text: str) -> Feature:
+        feature_path = directory / "variables.feature"
+        feature_path.write_text(textwrap.dedent(text).strip(), encoding="utf-8")
+        return parse_file(str(feature_path))
+
+    def _make_context(self, features: list[Feature]) -> Context:
+        runner = Runner(Configuration(load_config=False))
+        runner.features = list(features)
+        context = Context(runner)
+        context._behave_toolkit_test_runner = runner  # pylint: disable=protected-access
+        return context
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_step_docs.py
+++ b/tests/test_step_docs.py
@@ -123,6 +123,26 @@ class StepDocumentationTests(unittest.TestCase):
             )
             self.assertEqual(len(step_pages), 3)
 
+    def test_generate_step_docs_can_resolve_feature_variables_for_examples(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            features_dir, config_path = self._write_feature_variable_project(project_root)
+            output_dir = project_root / "docs" / "behave-toolkit"
+            generate_step_docs(
+                features_dir,
+                output_dir,
+                config_path=config_path,
+            )
+
+            step_pages = sorted(
+                path
+                for path in (output_dir / "steps").glob("*.md")
+                if path.name not in {"index.md", "given.md", "when.md", "then.md", "generic.md"}
+            )
+            self.assertEqual(len(step_pages), 1)
+            step_page = step_pages[0].read_text(encoding="utf-8")
+            self.assertIn("`Given I have a active account`", step_page)
+
     def test_generate_step_docs_requires_steps_directory(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             features_dir = Path(tmpdir) / "features"
@@ -232,10 +252,47 @@ Feature: Demo step catalog
     Given I have a active account
     When I open 2 tabs
     Then the dashboard is ready
+                """.strip(),
+                encoding="utf-8",
+            )
+        return features_dir
+
+    def _write_feature_variable_project(self, project_root: Path) -> tuple[Path, Path]:
+        features_dir = project_root / "features"
+        steps_dir = features_dir / "steps"
+        steps_dir.mkdir(parents=True)
+
+        (steps_dir / "account_steps.py").write_text(
+            """
+from behave import given
+
+
+@given("I have a active account")
+def step_have_active_account(context):
+    \"\"\"Resolve examples from feature variables.\"\"\"
+    del context
             """.strip(),
             encoding="utf-8",
         )
-        return features_dir
+        (features_dir / "demo.feature").write_text(
+            """
+Feature: Demo variables
+
+  Scenario: Account overview
+    Given I have a {{var:status}} account
+            """.strip(),
+            encoding="utf-8",
+        )
+        config_path = features_dir / "behave-toolkit.yaml"
+        config_path.write_text(
+            """
+version: 1
+variables:
+  status: active
+            """.strip(),
+            encoding="utf-8",
+        )
+        return features_dir, config_path
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add `substitute_feature_variables(context)` to resolve `{{var:name}}` placeholders from root config variables inside parsed feature models
- cover feature, rule, background, and scenario names, description lines, step text, docstrings, tables, and `Scenario Outline` examples
- extend `generate_step_docs(..., config_path=...)` and `behave-toolkit-docs --config-path` so generated step examples stay aligned
- document the new helper and the recommended `before_all()` ordering

## Validation

- `python -m unittest discover -s tests -v`
- `python -m mypy src tests test_support.py`
- `python -m pylint src tests test_support.py`
- `python -m sphinx -W --keep-going -b html docs docs\_build\html`

Closes #7